### PR TITLE
Fix irc-addressed false positives

### DIFF
--- a/lib/IRC/Client.pm6
+++ b/lib/IRC/Client.pm6
@@ -245,9 +245,7 @@ method !handle-event ($e) {
             when 'irc-privmsg-channel' | 'irc-notice-channel' {
                 my $nick    = $s.current-nick;
                 my @aliases = $s.alias;
-                if $e.text .= subst:
-                    /^ [ $nick | @aliases ] <[,:]> \s* /, ''
-                {
+                if $e.text ~~ s/^ [ $nick | @aliases ] <[,:]> \s*// {
                     take 'irc-addressed', ('irc-to-me' if $s.is-connected);
                 }
                 elsif $e.text ~~ / << [ $nick | @aliases ] >> /


### PR DESCRIPTION
Commit 3e585499 replaced a `subst-mutate` with a `.= subst` as a
result of a v6.d deprecation. The surrounding code relied on the
return value being falsy when no substitution took place. This was
true for `subst-mutate` but isn't for `subst` which always returns
the resulting string. In this case, this caused every PRIVMSG to
fire an `irc-addressed` event.

This is fixed by using s///, which mutates but returns the Match
(or Nil).